### PR TITLE
Options safing fix

### DIFF
--- a/Bohemian.toc
+++ b/Bohemian.toc
@@ -1,7 +1,7 @@
 ## Interface: 30402
 ## Title: |cFF4068E0Bohemian|r
 ## Author: Elerae-Golemagg
-## Version: 4.4.5
+## Version: 4.4.6
 ## SavedVariablesPerCharacter: BohemianConfig
 
 libs\libs.xml

--- a/core/core.lua
+++ b/core/core.lua
@@ -227,6 +227,26 @@ function E:SendRequiredModules(sender)
     end
 end
 
+function E:SaveOptions()
+    for _, name in pairs(self.AVAILABLE_MODULES) do
+        self:Debug("Saving options for module", name)
+        local module = self.MODULES[name]
+        if module then
+            BohemkaDKPInterfaceOptionsPanel[name.."_okay"]()
+        end
+    end
+end
+
+function E:CancelOptions()
+    for _, name in pairs(self.AVAILABLE_MODULES) do
+        self:Debug("Cancelling options for module", name)
+        local module = self.MODULES[name]
+        if module then
+            BohemkaDKPInterfaceOptionsPanel[name.."_cancel"]()
+        end
+    end
+end
+
 function E:Init()
     if E.disabled or E.initialized then
         return

--- a/core/core.lua
+++ b/core/core.lua
@@ -231,7 +231,11 @@ function E:SaveOptions()
     for _, name in pairs(self.AVAILABLE_MODULES) do
         self:Debug("Saving options for module", name)
         local module = self.MODULES[name]
-        if module then
+        if module and 
+    	   (name == "Auction" or
+    	    name == "DKP" or
+    	    name == "Log" or
+    	    name == "Raid") then
             BohemkaDKPInterfaceOptionsPanel[name.."_okay"]()
         end
     end
@@ -241,7 +245,11 @@ function E:CancelOptions()
     for _, name in pairs(self.AVAILABLE_MODULES) do
         self:Debug("Cancelling options for module", name)
         local module = self.MODULES[name]
-        if module then
+        if module and 
+    	   (name == "Auction" or
+    	    name == "DKP" or
+    	    name == "Log" or
+    	    name == "Raid") then
             BohemkaDKPInterfaceOptionsPanel[name.."_cancel"]()
         end
     end

--- a/core/ui.lua
+++ b/core/ui.lua
@@ -497,10 +497,12 @@ function E:CreateInterfaceConfig()
         BohemianConfig.debug = BohemkaDKPInterfaceOptionsPanelDebug:GetChecked()
         BohemianConfig.cpsLimit = BohemkaDKPInterfaceOptionsPanelEditBoxCpsLimit:GetNumber()
         E:SendRequiredModules()
+        E:SaveOptions()
     end
     BohemkaDKPInterfaceOptionsPanel.cancel = function()
         BohemkaDKPInterfaceOptionsPanelDebug:SetChecked(BohemianConfig.debug)
         BohemkaDKPInterfaceOptionsPanelEditBoxCpsLimit:SetNumber(BohemianConfig.cpsLimit)
+        E:CancelOptions()
     end
 
     InterfaceOptions_AddCategory(f)

--- a/plugins/Bohemian_Auction/ui.lua
+++ b/plugins/Bohemian_Auction/ui.lua
@@ -761,7 +761,7 @@ function E:AddConfigFrames(f)
     font2:SetPoint("TOPLEFT", font, "BOTTOMLEFT", 0, 5)
     font2:SetText("Item Name=10\nItem Name2=30")
     local name = f:GetName()
-    f.okay = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Auction_okay = function()
         Bohemian_AuctionConfig.itemPrices = C:ConfigTextToTable(_G[name.."EditBoxItemPriceItemPrice"]:GetText())
         Bohemian_AuctionConfig.minBid = _G[name.."EditBoxMinimalBid"]:GetNumber()
         Bohemian_AuctionConfig.minItemPrice = _G[name.."EditBoxMinItemPrice"]:GetNumber()
@@ -769,11 +769,11 @@ function E:AddConfigFrames(f)
         Bohemian_AuctionConfig.startingDKP = _G[name.."EditBoxStartingDKP"]:GetNumber()
         Bohemian_AuctionConfig.bidCooldown = _G[name.."EditBoxBidCooldown"]:GetNumber()
         Bohemian_AuctionConfig.showBidInfoInChat = _G[name.."ShowBidInfoInChat"]:GetChecked()
-        Bohemian_AuctionConfig.startAuctionModifier = UIDropDownMenu_GetSelectedValue(_G[name.."AuctionKeyBind"])
+        Bohemian_AuctionConfig.startAuctionModifier = UIDropDownMenu_GetSelectedValue(auctionStartKeyBind)
         Bohemian_AuctionConfig.addToCurrentAmount = _G[name.."ToggleAuctionMode"]:GetChecked()
     end
 
-    f.cancel = function()
+    fBohemkaDKPInterfaceOptionsPanel.Bohemian_Auction_cancel = function()
         _G[name.."EditBoxItemPriceItemPrice"]:SetText(C:TableToConfigText(Bohemian_AuctionConfig.itemPrices))
         _G[name.."EditBoxMinimalBid"]:SetNumber(Bohemian_AuctionConfig.minBid)
         _G[name.."EditBoxMinItemPrice"]:SetNumber(Bohemian_AuctionConfig.minItemPrice)
@@ -782,7 +782,7 @@ function E:AddConfigFrames(f)
         _G[name.."EditBoxBidCooldown"]:SetNumber(Bohemian_AuctionConfig.bidCooldown)
         _G[name.."ShowBidInfoInChat"]:SetChecked(Bohemian_AuctionConfig.showBidInfoInChat)
         _G[name.."ToggleAuctionMode"]:SetChecked(Bohemian_AuctionConfig.addToCurrentAmount)
-        UIDropDownMenu_SetSelectedValue(_G[name.."AuctionKeyBind"], Bohemian_AuctionConfig.startAuctionModifier);
+        UIDropDownMenu_SetSelectedValue(auctionStartKeyBind, Bohemian_AuctionConfig.startAuctionModifier);
     end
 end
 

--- a/plugins/Bohemian_Auction/ui.lua
+++ b/plugins/Bohemian_Auction/ui.lua
@@ -773,7 +773,7 @@ function E:AddConfigFrames(f)
         Bohemian_AuctionConfig.addToCurrentAmount = _G[name.."ToggleAuctionMode"]:GetChecked()
     end
 
-    fBohemkaDKPInterfaceOptionsPanel.Bohemian_Auction_cancel = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Auction_cancel = function()
         _G[name.."EditBoxItemPriceItemPrice"]:SetText(C:TableToConfigText(Bohemian_AuctionConfig.itemPrices))
         _G[name.."EditBoxMinimalBid"]:SetNumber(Bohemian_AuctionConfig.minBid)
         _G[name.."EditBoxMinItemPrice"]:SetNumber(Bohemian_AuctionConfig.minItemPrice)

--- a/plugins/Bohemian_DKP/ui.lua
+++ b/plugins/Bohemian_DKP/ui.lua
@@ -734,12 +734,12 @@ function E:AddConfigFrames(f)
         E:ShowBossRewardEditBox(frameName, self.value)
     end
 
-    f.okay = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_DKP_okay = function()
         for index, difficulty in ipairs(difficulties) do
             Bohemian_DKPConfig.bossRewards[difficulty[1]] = C:ConfigTextToTable(E:GetBossRewardEditBox(frameName, difficulty[1]).editbox:GetText())
         end
     end
-    f.cancel = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_DKP_cancel = function()
         for index, difficulty in ipairs(difficulties) do
             E:GetBossRewardEditBox(frameName, difficulty[1]).editbox:SetText(C:TableToConfigText(Bohemian_DKPConfig.bossRewards[difficulty[1]]))
         end

--- a/plugins/Bohemian_Log/ui.lua
+++ b/plugins/Bohemian_Log/ui.lua
@@ -608,10 +608,10 @@ function E:AddConfigFrames(f)
         StaticPopup_Show("WIPE_DATA_ALL")
     end)
     local name = f:GetName()
-    f.okay = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Log_okay = function()
         Bohemian_LogConfig.autoBackup = _G[name.."EditBoxAutoBackup"]:GetNumber()
     end
-    f.cancel = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Log_cancel = function()
         _G[name.."EditBoxAutoBackup"]:SetNumber(Bohemian_LogConfig.autoBackup)
     end
 

--- a/plugins/Bohemian_Raid/ui.lua
+++ b/plugins/Bohemian_Raid/ui.lua
@@ -64,14 +64,14 @@ function E:AddConfigFrames(f)
     local title, _ = C:AddConfigEditBox(f, {"TOPLEFT", font, "BOTTOMLEFT", 0, -10}, "GuildRaidMinimalCount", "Guild Raid members", Bohemian_RaidConfig.guildRaidMemberRatio, "%")
 
     local name = f:GetName()
-    f.okay = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Raid_okay = function()
         Bohemian_RaidConfig.announceParry = _G[name.."AnnounceParry"]:GetChecked()
         Bohemian_RaidConfig.announceMD = _G[name.."AnnounceMD"]:GetChecked()
         Bohemian_RaidConfig.raidHours = _G[name.."RaidHours"]:GetChecked()
         Bohemian_RaidConfig.guildRaidMemberRatio = tonumber(_G[name.."EditBoxGuildRaidMinimalCount"]:GetText())
     end
 
-    f.cancel = function()
+    BohemkaDKPInterfaceOptionsPanel.Bohemian_Raid_cancel = function()
         _G[name.."AnnounceParry"]:SetChecked(Bohemian_RaidConfig.announceParry)
         _G[name.."AnnounceMD"]:SetChecked(Bohemian_RaidConfig.announceMD)
         _G[name.."RaidHours"]:SetChecked(Bohemian_RaidConfig.raidHours)


### PR DESCRIPTION
In latest update blizzard changed how the options menu invokes the ".okay" action. It seems like it now only calls a global action instead of submenu action. The proper fix I saw in other addons is to add some mixins and invoke the action from them but I don't want to spend a week on this. 
This fix is hacky but it works.